### PR TITLE
[TASK] Remove readonly to make it compatible with php 8.1

### DIFF
--- a/Classes/Backend/Controller/AdminModuleController.php
+++ b/Classes/Backend/Controller/AdminModuleController.php
@@ -35,9 +35,9 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 final class AdminModuleController
 {
     public function __construct(
-        private readonly ModuleTemplateFactory $moduleTemplateFactory,
-        private readonly ProvideExternalLinkListService $provideExternalLinkListService,
-        private readonly ProvideParsedLinkListService $provideParsedLinkListService,
+        private ModuleTemplateFactory $moduleTemplateFactory,
+        private ProvideExternalLinkListService $provideExternalLinkListService,
+        private ProvideParsedLinkListService $provideParsedLinkListService,
     ) {}
 
     public function handleRequest(ServerRequestInterface $request): ResponseInterface

--- a/Classes/Service/ProvideExternalLinkListService.php
+++ b/Classes/Service/ProvideExternalLinkListService.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-final readonly class ProvideExternalLinkListService
+final class ProvideExternalLinkListService
 {
     public function __construct() {}
 

--- a/Classes/Service/ProvideParsedLinkListService.php
+++ b/Classes/Service/ProvideParsedLinkListService.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
-final readonly class ProvideParsedLinkListService
+final class ProvideParsedLinkListService
 {
     public function getConfiguration(bool $useCache = true): array
     {

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         }
     ],
     "require": {
+        "php": "^8.1",
         "typo3/cms-core": "^12.4 || ^13.4 || 14.0.*@dev"
     },
     "require-dev": {


### PR DESCRIPTION
Hi. 
I wanted to run this with php 8.1 so i had to remove the "readonly" properties.
The composer.json did not specify the php version, so it installed fine but broke the website. 
Without the readonly properties the extension is backwards compatible with 8.1.